### PR TITLE
Simplify class construction and improve efficiencies

### DIFF
--- a/Archer.lua
+++ b/Archer.lua
@@ -233,9 +233,9 @@ function Archer:GetNearbyNodes(Position, Range)
 	local Strings = {}
 	setmetatable(Out, {__index=table})
 
-	for xdelta = -1, 1, 1 do 
-		for ydelta = -1, 1, 1 do 
-			for zdelta = -1, 1, 1 do 
+	for xdelta = -1, 1 do 
+		for ydelta = -1, 1 do 
+			for zdelta = -1, 1 do 
 					local nVec = {x = Position.x + xdelta * Range, y = Position.y + ydelta * Range, z = Position.z + zdelta * Range}				
 				
 					local MyNodeString = self:GetNode(nVec)

--- a/Archer.lua
+++ b/Archer.lua
@@ -1,4 +1,5 @@
 local Archer = {}
+Archer.__index = Archer
 
 -- Archer range. Archer will not work for ranged checks which are bigger than Range.
 -- [note] It will not error, but it will miss targets.
@@ -11,17 +12,15 @@ Archer.Mode = "PerInstance" -- Either "PerInstance" or "PerJob".
 -- Per Instance: :StartThread() will loop over all instances, then calling all jobs
 -- Per Job: :StartThread() will loop over all jobs, then calling all instances
 
--- Instinct auto-calls this;
-function Archer:Constructor()
+function Archer:New()
+	local self = {}
+	setmetatable(self, Archer)
+
 	self.Tree = {} 
 	self.Jobs = {}
-end
 
-function Archer:New()
-	local my = setmetatable({}, {__index=self})
-	my:Constructor()
-	return my
-end 
+	return self
+end
 
 -- PUBLIC functions --
 

--- a/Archer.lua
+++ b/Archer.lua
@@ -53,7 +53,7 @@ function Archer:Add(Inst)
 end 
 
 function Archer:StartThread()
-	delay(0, function()
+	assert(coroutine.resume(coroutine.create(function()
 		if self.Mode == "PerJob" then 
 			while wait(1/10) do 
 				for _, Job in pairs(self.Jobs) do 
@@ -67,7 +67,7 @@ function Archer:StartThread()
 		else 
 			error(self.Mode .. " mode is unknown for archer. Aborting.")
 		end 
-	end)
+	end)))
 end 
 
 -- Manually call job is possible.


### PR DESCRIPTION
I simplified the construction while simultaneously avoiding bad practices in OOP. There's also a few small efficiency changes and a way that the thread-start is handled. 

I should note that the thread resume may break some code if and only if you assume the thread will not resume until after call, not at immediately call, although the way the API is defined, this is a bad assumption to make.

I also would prefer the constructor be `Archer.new()`, not `Archer:New()` to conform with Rbx.Lua standards, but this is not necessary. I left it as `Archer:New()` to leave test-cases operating in the same way.
